### PR TITLE
removing dynamic scopes

### DIFF
--- a/Sources/CASimEngine/CARuleScope.swift
+++ b/Sources/CASimEngine/CARuleScope.swift
@@ -1,15 +1,10 @@
-public import Voxels
-
-/// The set of voxels to process.
+/// The set of voxels for a rule to process.
+///
+/// When a voxel is updated by a rule, the engine adds it to an internal list of active voxels.
+/// If a rule doesn't update a voxel, the voxel is removed from the list of active voxels.
 public enum CARuleScope: Sendable {
     /// All voxels in the engine.
     case all
     /// The set of voxels that were updated by the previous rule.
     case active
-    /// A single voxel index.
-    case index(VoxelIndex)
-    /// A range of voxels.
-    case bounds(VoxelBounds)
-    /// A specified collection of indices
-    case collection([VoxelIndex])
 }

--- a/Sources/CASimEngine/CASimulationEngine.swift
+++ b/Sources/CASimEngine/CASimulationEngine.swift
@@ -112,44 +112,6 @@ public final class CASimulationEngine<T: Sendable> {
                 }
             }
             activeVoxels = newActives
-        case let .bounds(scopeBounds):
-            // DOES NOT influence set of actives
-            assert(currentVoxels.bounds.contains(scopeBounds))
-            for i in scopeBounds {
-                guard var temp = currentVoxels[i] else { continue }
-                let result = rule.evaluate(index: i, readVoxels: currentVoxels, newVoxel: &temp, deltaTime: deltaTime)
-                if result.updatedVoxel {
-                    newVoxels[i] = temp
-                }
-                if let diagnostic = result.diagnostic {
-                    _diagnosticContinuation.yield(
-                        CADiagnostic(index: i, rule: rule.name, messages: diagnostic.messages))
-                }
-            }
-        case let .index(singleIndex):
-            // DOES NOT influence set of actives
-            if var temp = currentVoxels[singleIndex] {
-                let result = rule.evaluate(index: singleIndex, readVoxels: currentVoxels, newVoxel: &temp, deltaTime: deltaTime)
-                if result.updatedVoxel {
-                    newVoxels[singleIndex] = temp
-                }
-                if let diagnostic = result.diagnostic {
-                    _diagnosticContinuation.yield(
-                        CADiagnostic(index: singleIndex, rule: rule.name, messages: diagnostic.messages))
-                }
-            }
-        case let .collection(indices):
-            for i in indices {
-                guard var temp = currentVoxels[i] else { continue }
-                let result = rule.evaluate(index: i, readVoxels: currentVoxels, newVoxel: &temp, deltaTime: deltaTime)
-                if result.updatedVoxel {
-                    newVoxels[i] = temp
-                }
-                if let diagnostic = result.diagnostic {
-                    _diagnosticContinuation.yield(
-                        CADiagnostic(index: i, rule: rule.name, messages: diagnostic.messages))
-                }
-            }
         }
 
         if activeStorage {
@@ -214,56 +176,6 @@ public final class CASimulationEngine<T: Sendable> {
                 }
             }
             activeVoxels = newActives
-        case let .bounds(scopeBounds):
-            // DOES NOT influence set of actives
-            assert(currentVoxels.bounds.contains(scopeBounds))
-            for i in scopeBounds {
-                guard var temp = currentVoxels[i] else { continue }
-                let result = rule.evaluate(index: i, readVoxels: currentVoxels, newVoxel: &temp, deltaTime: deltaTime)
-                if result.updatedVoxel {
-                    newVoxels[i] = temp
-                }
-                if result.updatedVoxel {
-                    diagnostics.append(
-                        CADetailedDiagnostic(index: i, rule: rule.name, initialValue: currentVoxels[i], finalValue: newVoxels[i], messages: result.diagnostic?.messages ?? [])
-                    )
-                } else {
-                    diagnostics.append(
-                        CADetailedDiagnostic(index: i, rule: rule.name, initialValue: currentVoxels[i], finalValue: nil, messages: result.diagnostic?.messages ?? [])
-                    )
-                }
-            }
-        case let .index(singleIndex):
-            // DOES NOT influence set of actives
-            if var temp = currentVoxels[singleIndex] {
-                let result = rule.evaluate(index: singleIndex, readVoxels: currentVoxels, newVoxel: &temp, deltaTime: deltaTime)
-                if result.updatedVoxel {
-                    newVoxels[singleIndex] = temp
-                }
-                if result.updatedVoxel {
-                    diagnostics.append(
-                        CADetailedDiagnostic(index: singleIndex, rule: rule.name, initialValue: currentVoxels[singleIndex], finalValue: newVoxels[singleIndex], messages: result.diagnostic?.messages ?? [])
-                    )
-                } else {
-                    diagnostics.append(
-                        CADetailedDiagnostic(index: singleIndex, rule: rule.name, initialValue: currentVoxels[singleIndex], finalValue: nil, messages: result.diagnostic?.messages ?? [])
-                    )
-                }
-            }
-        case let .collection(indices):
-            for i in indices {
-                guard var temp = currentVoxels[i] else { continue }
-                let result = rule.evaluate(index: i, readVoxels: currentVoxels, newVoxel: &temp, deltaTime: deltaTime)
-                if result.updatedVoxel {
-                    diagnostics.append(
-                        CADetailedDiagnostic(index: i, rule: rule.name, initialValue: currentVoxels[i], finalValue: newVoxels[i], messages: result.diagnostic?.messages ?? [])
-                    )
-                } else {
-                    diagnostics.append(
-                        CADetailedDiagnostic(index: i, rule: rule.name, initialValue: currentVoxels[i], finalValue: nil, messages: result.diagnostic?.messages ?? [])
-                    )
-                }
-            }
         }
 
         if activeStorage {

--- a/Sources/CASimEngine/Documentation.docc/CASimulationRule.md
+++ b/Sources/CASimEngine/Documentation.docc/CASimulationRule.md
@@ -10,4 +10,4 @@
 
 ### Applying the rule
 
-- ``evaluate``
+- ``evaluate(index:readVoxels:newVoxel:deltaTime:)``


### PR DESCRIPTION
They don't make sense with a rule that's a type up front - there's parameters that really should be evaluated late in the sequence, so adding them into the type structure for a rule that doesn't change doesn't make a lot of sense.