### PR TITLE
switching from set to array to track actives

### DIFF
--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -17,6 +17,10 @@ Comparing to a the baseline 'alpha'
 
     swift package benchmark baseline compare 0.1.0
 
+or, to output with markdown format to paste into a PR:
+
+    swift package benchmark baseline compare dev --format markdown
+
 For more details on creating and comparing baselines, read [Creating and Comparing Benchmark Baselines](https://swiftpackageindex.com/ordo-one/package-benchmark/main/documentation/benchmark/creatingandcomparingbaselines).
 
 ## baseline per tag:

--- a/Tests/CASimEngineTests/EngineFunctionalTests.swift
+++ b/Tests/CASimEngineTests/EngineFunctionalTests.swift
@@ -8,7 +8,7 @@ final class EngineFunctionalTests: XCTestCase {
         let seed = VoxelArray(bounds: bounds, initialValue: 0)
         XCTAssertEqual(seed.bounds.indices.count, 10 * 10 * 10)
         let engine = CASimulationEngine(seed, rules: [])
-        XCTAssertEqual(engine.activeVoxels.count, 10 * 10 * 10)
+        XCTAssertEqual(engine._actives.count, 10 * 10 * 10)
     }
 
     func testActiveScope() throws {
@@ -16,10 +16,10 @@ final class EngineFunctionalTests: XCTestCase {
         let seed = VoxelArray(bounds: bounds, initialValue: 0)
         let engine = CASimulationEngine(seed, rules: [IncrementActiveRule()])
 
-        XCTAssertEqual(engine.activeVoxels.count, 10 * 10 * 10)
+        XCTAssertEqual(engine._actives.count, 10 * 10 * 10)
 
         engine.tick(deltaTime: Duration(secondsComponent: 1, attosecondsComponent: 0))
-        XCTAssertEqual(engine.activeVoxels.count, 1000)
+        XCTAssertEqual(engine._actives.count, 1000)
     }
 
     func testActiveScopeNoEffect() throws {
@@ -27,10 +27,10 @@ final class EngineFunctionalTests: XCTestCase {
         let seed = VoxelArray(bounds: bounds, initialValue: 0)
         let engine = CASimulationEngine(seed, rules: [NoEffectRule()])
 
-        XCTAssertEqual(engine.activeVoxels.count, 10 * 10 * 10)
+        XCTAssertEqual(engine._actives.count, 10 * 10 * 10)
 
         engine.tick(deltaTime: Duration(secondsComponent: 1, attosecondsComponent: 0))
-        XCTAssertEqual(engine.activeVoxels.count, 0)
+        XCTAssertEqual(engine._actives.count, 0)
     }
 
     func testAllScope() throws {
@@ -38,8 +38,8 @@ final class EngineFunctionalTests: XCTestCase {
         let seed = VoxelArray(bounds: bounds, initialValue: 0)
         let engine = CASimulationEngine(seed, rules: [IncrementAllRule()])
 
-        XCTAssertEqual(engine.activeVoxels.count, 10 * 10 * 10)
+        XCTAssertEqual(engine._actives.count, 10 * 10 * 10)
         engine.tick(deltaTime: Duration(secondsComponent: 1, attosecondsComponent: 0))
-        XCTAssertEqual(engine.activeVoxels.count, 10 * 10 * 10)
+        XCTAssertEqual(engine._actives.count, 10 * 10 * 10)
     }
 }

--- a/Tests/CASimEngineTests/EngineSmokeTests.swift
+++ b/Tests/CASimEngineTests/EngineSmokeTests.swift
@@ -12,14 +12,12 @@ final class EngineSmokeTests: XCTestCase {
 
         XCTAssertEqual(seed.bounds.indices.count, 100 * 100 * 100)
 
-        // let rule = DirectNoEffectRule<Int>()
-
         let engine = CASimulationEngine(seed, rules: [IncrementAllRule()])
 
-        XCTAssertEqual(engine.activeVoxels.count, 100 * 100 * 100)
+        XCTAssertEqual(engine._actives.count, 100 * 100 * 100)
 
         engine.tick(deltaTime: Duration(secondsComponent: 1, attosecondsComponent: 0))
-        XCTAssertEqual(engine.activeVoxels.count, 1_000_000)
+        XCTAssertEqual(engine._actives.count, 1_000_000)
 
         measure {
             engine.tick(deltaTime: Duration(secondsComponent: 1, attosecondsComponent: 0))


### PR DESCRIPTION
resolves #15 

## Comparing results between 'dev' and 'Current_run'

```
Host 'MacBookPro' with 8 'arm64' processors with 16 GB memory, running:
Darwin Kernel Version 24.1.0: Thu Oct 10 21:05:14 PDT 2024; root:xnu-11215.41.3~2/RELEASE_ARM64_T8103
```
## EngineBenchmarks

### sim iteration metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

|         Time (wall clock) (ms) *         |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|
|                   dev                    |     300 |     302 |     303 |     304 |     304 |     304 |     304 |      15 |
|               Current_run                |     187 |     187 |     187 |     188 |     188 |     188 |     188 |      25 |
|                    Δ                     |    -113 |    -115 |    -116 |    -116 |    -116 |    -116 |    -116 |      10 |
|              Improvement %               |      38 |      38 |      38 |      38 |      38 |      38 |      38 |      10 |

<p>
</details>

<details><summary>Time (total CPU): results within specified thresholds, fold down for details.</summary>
<p>

|         Time (total CPU) (ms) *          |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|
|                   dev                    |     300 |     302 |     303 |     304 |     304 |     305 |     305 |      15 |
|               Current_run                |     187 |     187 |     187 |     188 |     188 |     188 |     188 |      25 |
|                    Δ                     |    -113 |    -115 |    -116 |    -116 |    -116 |    -117 |    -117 |      10 |
|              Improvement %               |      38 |      38 |      38 |      38 |      38 |      38 |      38 |      10 |

<p>
</details>

<details><summary>Throughput (# / s): results within specified thresholds, fold down for details.</summary>
<p>

|          Throughput (# / s) (#)          |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|
|                   dev                    |       3 |       3 |       3 |       3 |       3 |       3 |       3 |      15 |
|               Current_run                |       5 |       5 |       5 |       5 |       5 |       5 |       5 |      25 |
|                    Δ                     |       2 |       2 |       2 |       2 |       2 |       2 |       2 |      10 |
|              Improvement %               |      67 |      67 |      67 |      67 |      67 |      67 |      67 |      10 |

<p>
</details>

<details><summary>Memory (resident peak): results within specified thresholds, fold down for details.</summary>
<p>
  1 # Benchmarks for the CA Simulation Engine

|        Memory (resident peak) (M)        |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|
|                   dev                    |     203 |     206 |     206 |     206 |     206 |     206 |     206 |      15 |
|               Current_run                |      90 |      91 |      91 |      91 |      94 |      94 |      94 |      25 |
|                    Δ                     |    -113 |    -115 |    -115 |    -115 |    -112 |    -112 |    -112 |      10 |
|              Improvement %               |      56 |      56 |      56 |      56 |      54 |      54 |      54 |      10 |

<p>
</details>

<details><summary>Malloc (total): results within specified thresholds, fold down for details.</summary>
<p>

|             Malloc (total) *             |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|
|                   dev                    |      22 |      22 |      22 |      22 |      22 |      22 |      22 |      15 |
|               Current_run                |      22 |      22 |      22 |      22 |      22 |      22 |      22 |      25 |
|                    Δ                     |       0 |       0 |       0 |       0 |       0 |       0 |       0 |      10 |
|              Improvement %               |       0 |       0 |       0 |       0 |       0 |       0 |       0 |      10 |

<p>
</details>

<details><summary>Instructions: results within specified thresholds, fold down for details.</summary>
<p>

|            Instructions (M) *            |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|
|                   dev                    |    3142 |    3144 |    3144 |    3144 |    3144 |    3144 |    3144 |      15 |
|               Current_run                |    2560 |    2561 |    2561 |    2561 |    2561 |    2561 |    2561 |      25 |
|                    Δ                     |    -582 |    -583 |    -583 |    -583 |    -583 |    -583 |    -583 |      10 |
|              Improvement %               |      19 |      19 |      19 |      19 |      19 |      19 |      19 |      10 |

<p>
</details>