### PR TITLE
optimizing around the relatively inefficient subscript

### DIFF
--- a/Sources/CASimEngine/CASimulationEngine.swift
+++ b/Sources/CASimEngine/CASimulationEngine.swift
@@ -88,7 +88,7 @@ public final class CASimulationEngine<T: Sendable> {
                 let result = rule.evaluate(index: i, readVoxels: currentVoxels, newVoxel: &temp, deltaTime: deltaTime)
                 if result.updatedVoxel {
                     newActives.append(i)
-                    newVoxels[i] = temp
+                    newVoxels.set(i, newValue: temp)
                 }
                 if let diagnostic = result.diagnostic {
                     _diagnosticContinuation.yield(
@@ -102,7 +102,7 @@ public final class CASimulationEngine<T: Sendable> {
                 let result = rule.evaluate(index: i, readVoxels: currentVoxels, newVoxel: &temp, deltaTime: deltaTime)
                 if result.updatedVoxel {
                     newActives.append(i)
-                    newVoxels[i] = temp
+                    newVoxels.set(i, newValue: temp)
                 }
                 if let diagnostic = result.diagnostic {
                     _diagnosticContinuation.yield(


### PR DESCRIPTION
With the prior optimization, this jumps us up to 63% improvement in iteration speed


## Comparing results between '0.1.0' and 'Current_run'

```
Host 'MacBookPro' with 8 'arm64' processors with 16 GB memory, running:
Darwin Kernel Version 24.1.0: Thu Oct 10 21:05:14 PDT 2024; root:xnu-11215.41.3~2/RELEASE_ARM64_T8103
```
## EngineBenchmarks

### sim iteration metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

|         Time (wall clock) (ms) *         |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|
|                  0.1.0                   |     313 |     314 |     315 |     315 |     317 |     317 |     317 |      15 |
|               Current_run                |     115 |     116 |     116 |     117 |     117 |     118 |     118 |      30 |
|                    Δ                     |    -198 |    -198 |    -199 |    -198 |    -200 |    -199 |    -199 |      15 |
|              Improvement %               |      63 |      63 |      63 |      63 |      63 |      63 |      63 |      15 |

<p>
</details>

<details><summary>Time (total CPU): results within specified thresholds, fold down for details.</summary>
<p>

|         Time (total CPU) (ms) *          |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|
|                  0.1.0                   |     313 |     314 |     315 |     315 |     317 |     317 |     317 |      15 |
|               Current_run                |     115 |     116 |     117 |     117 |     118 |     118 |     118 |      30 |
|                    Δ                     |    -198 |    -198 |    -198 |    -198 |    -199 |    -199 |    -199 |      15 |
|              Improvement %               |      63 |      63 |      63 |      63 |      63 |      63 |      63 |      15 |

<p>
</details>

<details><summary>Throughput (# / s): results within specified thresholds, fold down for details.</summary>
<p>

|          Throughput (# / s) (#)          |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|
|                  0.1.0                   |       3 |       3 |       3 |       3 |       3 |       3 |       3 |      15 |
|               Current_run                |       9 |       9 |       9 |       9 |       9 |       9 |       9 |      30 |
|                    Δ                     |       6 |       6 |       6 |       6 |       6 |       6 |       6 |      15 |
|              Improvement %               |     200 |     200 |     200 |     200 |     200 |     200 |     200 |      15 |

<p>
</details>

<details><summary>Memory (resident peak): results within specified thresholds, fold down for details.</summary>
<p>

|        Memory (resident peak) (M)        |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|
|                  0.1.0                   |     203 |     206 |     206 |     206 |     206 |     206 |     206 |      15 |
|               Current_run                |      97 |     106 |     109 |     109 |     109 |     109 |     109 |      30 |
|                    Δ                     |    -106 |    -100 |     -97 |     -97 |     -97 |     -97 |     -97 |      15 |
|              Improvement %               |      52 |      49 |      47 |      47 |      47 |      47 |      47 |      15 |

<p>
</details>

<details><summary>Malloc (total): results within specified thresholds, fold down for details.</summary>
<p>

|             Malloc (total) *             |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|
|                  0.1.0                   |      22 |      22 |      22 |      22 |      22 |      22 |      22 |      15 |
|               Current_run                |      22 |      22 |      22 |      22 |      22 |      22 |      22 |      30 |
|                    Δ                     |       0 |       0 |       0 |       0 |       0 |       0 |       0 |      15 |
|              Improvement %               |       0 |       0 |       0 |       0 |       0 |       0 |       0 |      15 |

<p>
</details>

<details><summary>Instructions: results within specified thresholds, fold down for details.</summary>
<p>

|            Instructions (M) *            |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|
|                  0.1.0                   |    3358 |    3360 |    3362 |    3362 |    3363 |    3363 |    3363 |      15 |
|               Current_run                |    1706 |    1707 |    1707 |    1707 |    1708 |    1711 |    1711 |      30 |
|                    Δ                     |   -1652 |   -1653 |   -1655 |   -1655 |   -1655 |   -1652 |   -1652 |      15 |
|              Improvement %               |      49 |      49 |      49 |      49 |      49 |      49 |      49 |      15 |

<p>
</details>