### PR TITLE
engine.current, built-in swap at end

### DIFF
--- a/Sources/CASimEngine/CASimulationEngine.swift
+++ b/Sources/CASimEngine/CASimulationEngine.swift
@@ -31,6 +31,10 @@ public final class CASimulationEngine<T: CASimulationStorage> {
     public let diagnosticStream: AsyncStream<CADiagnostic>
     let _diagnosticContinuation: AsyncStream<CADiagnostic>.Continuation
 
+    var current: VoxelArray<T.T> {
+        storage0.current
+    }
+
 //    public init(_ seed: any VoxelAccessible<T>, rules: [CASimulationRule<T>]) {
     public init(_ seed: T, rules: [CASimulationRule<T>]) {
         #if canImport(os)
@@ -72,6 +76,7 @@ public final class CASimulationEngine<T: CASimulationStorage> {
                 #endif
             }
         }
+        swap(&storage0, &storage1)
         #if canImport(os)
             signposter.endInterval("tick", state)
         #endif

--- a/Sources/CASimEngine/CASimulationStorage.swift
+++ b/Sources/CASimEngine/CASimulationStorage.swift
@@ -11,4 +11,7 @@ public protocol CASimulationStorage<T> {
     init(_ voxels: VoxelArray<T>)
     /// Returns a collection of VoxelUpdate the represent the changed values in the simulation.
     func changes() -> [VoxelUpdate<T>]
+
+    /// The state of the storage reassembled into a VoxelArray.
+    var current: VoxelArray<T> { get }
 }

--- a/Tests/CASimEngineTests/EngineFunctionalTests.swift
+++ b/Tests/CASimEngineTests/EngineFunctionalTests.swift
@@ -16,7 +16,6 @@ final class EngineFunctionalTests: XCTestCase {
         let seed = VoxelArray(bounds: bounds, initialValue: 0)
         let engine = CASimulationEngine(SingleIntStorage(seed), rules: [
             .eval(name: "inc", scope: .active, IncrementSingleInt()),
-            .swap(name: "swap", SwapSingleInt()),
         ])
 
         XCTAssertEqual(engine._actives.count, 10 * 10 * 10)
@@ -30,7 +29,6 @@ final class EngineFunctionalTests: XCTestCase {
         let seed = VoxelArray(bounds: bounds, initialValue: 0)
         let engine = CASimulationEngine(SingleIntStorage(seed), rules: [
             .eval(name: "noop", scope: .active, NoEffect()),
-            .swap(name: "swap", SwapSingleInt()),
         ])
 
         XCTAssertEqual(engine._actives.count, 10 * 10 * 10)
@@ -44,11 +42,29 @@ final class EngineFunctionalTests: XCTestCase {
         let seed = VoxelArray(bounds: bounds, initialValue: 0)
         let engine = CASimulationEngine(SingleIntStorage(seed), rules: [
             .eval(name: "inc", scope: .all, IncrementSingleInt()),
-            .swap(name: "swap", SwapSingleInt()),
         ])
 
         XCTAssertEqual(engine._actives.count, 10 * 10 * 10)
         engine.tick(deltaTime: Duration(secondsComponent: 1, attosecondsComponent: 0))
         XCTAssertEqual(engine._actives.count, 10 * 10 * 10)
+    }
+
+    func testCurrentValue() throws {
+        let bounds = VoxelBounds(min: .init(0, 0, 0), max: .init(9, 9, 9))
+        let seed = VoxelArray(bounds: bounds, initialValue: 0)
+        let engine = CASimulationEngine(SingleIntStorage(seed), rules: [
+            .eval(name: "inc", scope: .active, IncrementSingleInt()),
+        ])
+        engine.tick(deltaTime: Duration(secondsComponent: 1, attosecondsComponent: 0))
+        engine.tick(deltaTime: Duration(secondsComponent: 1, attosecondsComponent: 0))
+
+        let expected = VoxelArray(bounds: bounds, initialValue: 2)
+        // XCTAssertEqual(engine.current, expected)
+
+        // workaround for now...
+        let current = engine.current
+        for i in bounds {
+            XCTAssertEqual(current[i], expected[i])
+        }
     }
 }

--- a/Tests/CASimEngineTests/EngineSmokeTests.swift
+++ b/Tests/CASimEngineTests/EngineSmokeTests.swift
@@ -1,6 +1,6 @@
 @testable internal import CASimEngine
 internal import Voxels
-import XCTest // import Testing for 6.0...
+import XCTest
 
 final class EngineSmokeTests: XCTestCase {
     func testSimplestRule() throws {
@@ -26,9 +26,6 @@ final class EngineSmokeTests: XCTestCase {
             engine.tick(deltaTime: Duration(secondsComponent: 1, attosecondsComponent: 0))
         }
         // standard test time: loosely 0.518 seconds (debug build)
-        // in profiling, it's showing ~112ms per iteration (release build)
-
-        // with the big ole reset to the code and storage, test time is: 0.436
-        // and in profiling, it's down to 75ms per iteration
+        // 0.427 - Xcode 16.2 beta 3
     }
 }

--- a/Tests/CASimEngineTests/ExampleStorage.swift
+++ b/Tests/CASimEngineTests/ExampleStorage.swift
@@ -30,4 +30,20 @@ public struct FluidSimStorage: CASimulationStorage {
     public func changes() -> [VoxelUpdate<T>] {
         []
     }
+
+    public var current: VoxelArray<T> {
+        var newArray = VoxelArray<T>(bounds: bounds, initialValue: .air)
+        for i in 0 ..< bounds.size {
+            let voxelIndex = bounds._unchecked_delinearize(i)
+            var instance = MultiResourceCell.air
+            instance.primaryTypeVolume = solid[i]
+            instance.liquidVolume = fluidMass[i]
+            instance.flowX = fluidVelX[i]
+            instance.flowY = fluidVelY[i]
+            instance.flowZ = fluidVelZ[i]
+            instance.pressure = fluidPressure[i]
+            newArray[voxelIndex] = instance
+        }
+        return newArray
+    }
 }

--- a/Tests/CASimEngineTests/SingleFloat.swift
+++ b/Tests/CASimEngineTests/SingleFloat.swift
@@ -18,6 +18,14 @@ struct SingleFloatStorage: CASimulationStorage {
     func changes() -> [VoxelUpdate<T>] {
         []
     }
+
+    public var current: VoxelArray<T> {
+        var newArray = VoxelArray<T>(bounds: bounds, initialValue: 0)
+        for i in 0 ..< bounds.size {
+            newArray[i] = floatValue[i]
+        }
+        return newArray
+    }
 }
 
 struct IncrementSingleFloat: EvaluateStep {

--- a/Tests/CASimEngineTests/SingleInt.swift
+++ b/Tests/CASimEngineTests/SingleInt.swift
@@ -5,18 +5,26 @@ struct SingleIntStorage: CASimulationStorage {
     public typealias T = Int
     let bounds: VoxelBounds
 
-    var floatValue: [T] = []
+    var intValue: [T] = []
 
     init(_ voxels: VoxelArray<T>) {
         bounds = voxels.bounds
         for i in 0 ..< bounds.size {
             // let voxelIndex = bounds._unchecked_delinearize(i)
-            floatValue.append(voxels[i])
+            intValue.append(voxels[i])
         }
     }
 
     func changes() -> [VoxelUpdate<T>] {
         []
+    }
+
+    public var current: VoxelArray<T> {
+        var newArray = VoxelArray<T>(bounds: bounds, initialValue: 0)
+        for i in 0 ..< bounds.size {
+            newArray[i] = intValue[i]
+        }
+        return newArray
     }
 }
 
@@ -24,7 +32,7 @@ struct IncrementSingleInt: EvaluateStep {
     typealias StorageType = SingleIntStorage
     func evaluate(linearIndex: Int, storage0: StorageType, storage1: inout StorageType) -> CARuleResult {
         // need read access to storage0 and write access to storage1
-        storage1.floatValue[linearIndex] = storage0.floatValue[linearIndex] + 1
+        storage1.intValue[linearIndex] = storage0.intValue[linearIndex] + 1
 
         // computing the voxelIndex from the linear index
         // let _ = storage0.bounds._unchecked_delinearize(linearIndex)


### PR DESCRIPTION
recreates `current` on the engine to provide an expected whole state output